### PR TITLE
change(package.json): change required NodeJS version

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "copy-template": "cp -R ./src/templates ./dist/"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=18.0.0"
   },
   "bugs": "https://github.com/AstarNetwork/swanky-cli/issues",
   "keywords": [

--- a/src/templates/package.json.tpl
+++ b/src/templates/package.json.tpl
@@ -12,6 +12,9 @@
     "compile": "swanky compile",
     "deploy": "swanky deploy"
   },
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "dependencies": {
     "@astar-network/swanky-cli": "{{swanky_version}}"
   }


### PR DESCRIPTION
Regarding https://github.com/AstarNetwork/swanky-cli/issues/20 I decided to make a very little PR to improve `package.json`, people works on many projects with many NodeJS versions and let them (like me) information about required NodeJS version in order to save time.