### PR TITLE
BugFixes for v1.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+### How to run locally
+```
+yarn
+npx lerna run build
+./packages/cli/bin/dev -h
+```

--- a/packages/cli/src/commands/contract/test.ts
+++ b/packages/cli/src/commands/contract/test.ts
@@ -66,7 +66,8 @@ export class CompileContract extends Command {
     tests.forEach((test) => {
       mocha.addFile(test);
     });
-    global.contractTypesPath = path.resolve(buildData.artifactsPath, "typedContract");
+
+    global.contractTypesPath = path.resolve("test", args.contractName, "typedContract");
     mocha.run((failures) => {
       if (failures) {
         this.error(`At least one of the tests failed. Check report for details: ${reportDir}`);

--- a/packages/core/src/lib/command-utils.ts
+++ b/packages/core/src/lib/command-utils.ts
@@ -84,7 +84,7 @@ export async function copyArtifactsFor(
       await Promise.all([
         fs.copyFile(
           path.resolve("artifacts", `${contractName}.contract`),
-          `${buildData.artifactsPath}/${contractName}.wasm`
+          `${buildData.artifactsPath}/${contractName}.contract`
         ),
         fs.copyFile(
           path.resolve("artifacts", `${contractName}.json`),

--- a/packages/core/src/lib/command-utils.ts
+++ b/packages/core/src/lib/command-utils.ts
@@ -93,7 +93,9 @@ export async function copyArtifactsFor(
       ]);
       //copy both to test/contract_name/artifacts
       const testArtifacts = path.resolve("test", contractName, "artifacts");
+      const testTypedContracts = path.resolve("test", contractName, "typedContract")
       await fs.ensureDir(testArtifacts);
+      await fs.ensureDir(testTypedContracts)
       await Promise.all([
         fs.copyFile(
           path.resolve("artifacts", `${contractName}.contract`),
@@ -103,7 +105,7 @@ export async function copyArtifactsFor(
           path.resolve("artifacts", `${contractName}.json`),
           `${testArtifacts}/${contractName}.json`
         ),
-        fs.move("typedContract", path.resolve("test", contractName, "typedContract"), {
+        fs.move("typedContract", testTypedContracts, {
           overwrite: true,
         }),
       ]);

--- a/packages/core/src/lib/command-utils.ts
+++ b/packages/core/src/lib/command-utils.ts
@@ -84,7 +84,7 @@ export async function copyArtifactsFor(
       await Promise.all([
         fs.copyFile(
           path.resolve("artifacts", `${contractName}.contract`),
-          `${buildData.artifactsPath}/${contractName}.contract`
+          `${buildData.artifactsPath}/${contractName}.wasm`
         ),
         fs.copyFile(
           path.resolve("artifacts", `${contractName}.json`),

--- a/packages/templates/src/templates/contracts/ink/flipper/contract/src/lib.rs.hbs
+++ b/packages/templates/src/templates/contracts/ink/flipper/contract/src/lib.rs.hbs
@@ -33,8 +33,9 @@ mod {{contract_name_snake}} {
         /// This one flips the value of the stored `bool` from `true`
         /// to `false` and vice versa.
         #[ink(message)]
-        pub fn flip(&mut self) {
+        pub fn flip(&mut self) -> bool {
             self.value = !self.value;
+            self.value
         }
 
         /// Simply returns the current value of our `bool`.

--- a/packages/templates/src/templates/contracts/ink/psp22/contract/src/lib.rs.hbs
+++ b/packages/templates/src/templates/contracts/ink/psp22/contract/src/lib.rs.hbs
@@ -1,9 +1,10 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![feature(min_specialization)]
 
-#[brush::contract]
+#[openbrush::contract]
 pub mod {{contract_name_snake}} {
     use ink_storage::traits::SpreadAllocate;
+    use ink_lang::codegen::{Env, EmitEvent};
     use openbrush::{
         contracts::psp22::*,
         traits::{
@@ -12,27 +13,27 @@ pub mod {{contract_name_snake}} {
         },
     };
 
-        #[ink(event)]
-        pub struct Transfer {
-            #[ink(topic)]
-            from: Option<AccountId>,
-            #[ink(topic)]
-            to: Option<AccountId>,
-            value: Balance,
-        }
+    #[ink(event)]
+    pub struct TransferEvent {
+        #[ink(topic)]
+        from: Option<AccountId>,
+        #[ink(topic)]
+        to: Option<AccountId>,
+        value: Balance,
+    }
 
-        #[ink(event)]
-        pub struct Approval {
-            #[ink(topic)]
-            owner: AccountId,
-            #[ink(topic)]
-            spender: AccountId,
-            value: Balance,
-        }
+    #[ink(event)]
+    pub struct ApprovalEvent {
+        #[ink(topic)]
+        owner: AccountId,
+        #[ink(topic)]
+        spender: AccountId,
+        value: Balance,
+    }
 
     #[ink(storage)]
     #[derive(Default, SpreadAllocate, Storage)]
-    pub struct Contract {
+    pub struct {{contract_name_pascal}} {
         #[storage_field]
         psp22: psp22::Data,
         // fields for hater logic
@@ -61,7 +62,7 @@ pub mod {{contract_name_snake}} {
             to: Option<AccountId>,
             amount: Balance,
         ) {
-            self.env().emit_event(Transfer {
+            self.env().emit_event(TransferEvent {
                 from,
                 to,
                 value: amount,
@@ -69,7 +70,7 @@ pub mod {{contract_name_snake}} {
         }
 
         fn _emit_approval_event(&self, owner: AccountId, spender: AccountId, amount: Balance) {
-            self.env().emit_event(Approval {
+            self.env().emit_event(ApprovalEvent {
                 owner,
                 spender,
                 value: amount,


### PR DESCRIPTION
Bugfixes.
This PR includes
- Fix invalid PSP22 template
- `swanky contract compile` failure because `test/{contractName}/typedContract` path not exist
- Fix `swanky contract test`, typechain-polkadot for some reason cannot handle returned value `()` (i.e. `fn flip() {`) or `Ok(())` (i.e. `fn flip() -> Result<(), ()> {`). As a workaround for the short term, returning a boolean for flip method.

and more to come