### PR TITLE
Allow contracts ui cors origin

### DIFF
--- a/packages/cli/src/commands/node/start.ts
+++ b/packages/cli/src/commands/node/start.ts
@@ -20,7 +20,9 @@ export class StartNode extends Command {
 
     const config = await getSwankyConfig();
     // run persistent mode by default. non-persistent mode in case flag is provided.
-    await execa.command(`${config.node.localPath} ${flags.tmp ? "--dev" : ""}`, {
+    await execa.command(`${config.node.localPath} \
+      --rpc-cors http://localhost:*,http://127.0.0.1:*,https://localhost:*,https://127.0.0.1:*,https://polkadot.js.org,https://contracts-ui.substrate.io/ \
+      ${flags.tmp ? "--dev" : ""}`, {
       stdio: "inherit",
     });
 


### PR DESCRIPTION
Allow CORS origin `https://contracts-ui.substrate.io/`.
Others are the same as before.