### PR TITLE
more appropreate cors setting, None for --tmp flag

### DIFF
--- a/packages/cli/src/commands/node/start.ts
+++ b/packages/cli/src/commands/node/start.ts
@@ -21,8 +21,7 @@ export class StartNode extends Command {
     const config = await getSwankyConfig();
     // run persistent mode by default. non-persistent mode in case flag is provided.
     await execa.command(`${config.node.localPath} \
-      --rpc-cors http://localhost:*,http://127.0.0.1:*,https://localhost:*,https://127.0.0.1:*,https://polkadot.js.org,https://contracts-ui.substrate.io/ \
-      ${flags.tmp ? "--dev" : ""}`, {
+      ${flags.tmp ? "--dev" : "--rpc-cors http://localhost:*,http://127.0.0.1:*,https://localhost:*,https://127.0.0.1:*,https://polkadot.js.org,https://contracts-ui.substrate.io/"}`, {
       stdio: "inherit",
     });
 

--- a/packages/cli/src/commands/node/start.ts
+++ b/packages/cli/src/commands/node/start.ts
@@ -19,9 +19,10 @@ export class StartNode extends Command {
     const { flags } = await this.parse(StartNode);
 
     const config = await getSwankyConfig();
+    const rpcCors = "http://localhost:*,http://127.0.0.1:*,https://localhost:*,https://127.0.0.1:*,https://polkadot.js.org,https://contracts-ui.substrate.io/";
     // run persistent mode by default. non-persistent mode in case flag is provided.
     await execa.command(`${config.node.localPath} \
-      ${flags.tmp ? "--dev" : "--rpc-cors http://localhost:*,http://127.0.0.1:*,https://localhost:*,https://127.0.0.1:*,https://polkadot.js.org,https://contracts-ui.substrate.io/"}`, {
+      ${flags.tmp ? "--dev" : `--rpc-cors ${rpcCors}`}`, {
       stdio: "inherit",
     });
 


### PR DESCRIPTION
More appropriate cors setting for local node.
When running substrate node with `--dev` flag, cors will set to None which means allowing all.

This PR changes cors setting to use specified ones (`--rpc-cors`) only when running node with non-dev mode.