### PR TITLE
Release build option flag

### DIFF
--- a/packages/cli/src/commands/contract/compile.ts
+++ b/packages/cli/src/commands/contract/compile.ts
@@ -8,10 +8,9 @@ import {
   getSwankyConfig,
   BuildData,
   Spinner,
-  generateTypes,
 } from "@astar-network/swanky-core";
 import { writeJSON } from "fs-extra";
-import execa = require("execa");
+
 export class CompileContract extends Command {
   static description = "Compile the smart contract(s) in your contracts directory";
 
@@ -21,6 +20,11 @@ export class CompileContract extends Command {
       char: "v",
       description: "Display additional compilation output",
     }),
+    release: Flags.boolean({
+      default: false,
+      char: "r",
+      description: "A production contract should always be build in `release` mode for building optimized wasm"
+    })
   };
 
   static args = [
@@ -56,7 +60,7 @@ export class CompileContract extends Command {
     await spinner.runCommand(
       async () => {
         return new Promise<void>((resolve, reject) => {
-          const build = getBuildCommandFor(contractInfo.language, contractPath);
+          const build = getBuildCommandFor(contractInfo.language, contractPath, flags.release);
           build.stdout.on("data", () => spinner.ora.clear());
           build.stdout.pipe(process.stdout);
           if (flags.verbose) {

--- a/packages/core/src/lib/command-utils.ts
+++ b/packages/core/src/lib/command-utils.ts
@@ -44,10 +44,11 @@ export function resolveNetworkUrl(config: SwankyConfig, networkName: string): st
 
 export function getBuildCommandFor(
   language: ContractData["language"],
-  contractPath: string
+  contractPath: string,
+  release: boolean,
 ): ChildProcessWithoutNullStreams {
   if (language === "ink") {
-    return spawn("npx", ["typechain-compiler"]);
+    return spawn("npx", ["typechain-compiler", release ? "--release" : ""]);
   }
   if (language === "ask") {
     return spawn(


### PR DESCRIPTION
For ink! contract compilation, production contracts need build optimization.
swanky-cli allows contracts being compiled as optimized wasm by taking `--release` flag.
`false` by default.