### PR TITLE
Allow users to specify contract constructor name

### DIFF
--- a/packages/cli/src/commands/contract/deploy.ts
+++ b/packages/cli/src/commands/contract/deploy.ts
@@ -33,6 +33,11 @@ export class DeployContract extends Command {
       char: "a",
       multiple: true,
     }),
+    constructorName: Flags.string({
+      default: "new",
+      char: "c",
+      description: "Constructor function name of a contract to deploy",
+    }),
     network: Flags.string({
       char: "n",
       description: "Network name to connect to",
@@ -121,6 +126,7 @@ export class DeployContract extends Command {
         const contractAddress = await api.deploy(
           abi,
           wasm,
+          flags.constructorName,
           account.pair,
           flags.gas,
           flags.args as string[]

--- a/packages/core/src/lib/deploy-api.ts
+++ b/packages/core/src/lib/deploy-api.ts
@@ -17,17 +17,17 @@ export class DeployApi extends ChainApi {
   public async deploy(
     abi: Abi,
     wasm: Buffer,
+    constructorName: string,
     signerPair: KeyringPair,
     gasLimit: number,
     args: string[]
   ) {
     const code = new CodePromise(this._api, abi, wasm);
     const storageDepositLimit = null;
-    // TODO: make other constructor names passable by flag
-    if (typeof code.tx.new !== "function") {
-      throw new Error("Contract has no constructor called 'New'");
+    if (typeof code.tx[constructorName] !== "function") {
+      throw new Error(`Contract has no constructor called ${constructorName}`);
     }
-    const tx = code.tx.new({ gasLimit, storageDepositLimit }, ...args);
+    const tx = code.tx[constructorName]({ gasLimit, storageDepositLimit }, ...(args || []));
     return new Promise((resolve, reject) => {
       this.signAndSend(signerPair, tx, {}, ({ status, events }) => {
         if (status.isInBlock || status.isFinalized) {


### PR DESCRIPTION
Part of https://github.com/AstarNetwork/swanky-cli/issues/63
Close https://github.com/AstarNetwork/swanky-cli/issues/35

This changes allow users to input and specify contract constructor name when deploying.
swanky-cli can manage arbitrary constructor name contracts.

Plus, fixed `contract deploy` command error when deploying contracts whose constructor takes no args.
```
DeployingTypeError: args is not iterable (cannot read property undefined)
```
