### PR TITLE
 Node download percentage limited to 2 decimals.

### DIFF
--- a/packages/core/src/lib/tasks.ts
+++ b/packages/core/src/lib/tasks.ts
@@ -95,7 +95,7 @@ export async function downloadNode(projectPath: string, nodeInfo: nodeInfo, spin
     const dl = new DownloaderHelper(dlUrl, binPath);
 
     dl.on("progress", (event) => {
-      spinner.text(`Downloading Swanky node ${event.progress}%`);
+      spinner.text(`Downloading Swanky node ${event.progress.toFixed(2)}%`);
     });
     dl.on("end", (event) => {
       resolve(event);


### PR DESCRIPTION
 Node download percentage during init should be limited to 2 decimals. #37. Since event.progress is a number, adding .toFixed(2) to the end of it will limit it to 2 decimals