### PR TITLE
Fix child process error handling at contract compilation.

### DIFF
--- a/packages/cli/src/commands/contract/compile.ts
+++ b/packages/cli/src/commands/contract/compile.ts
@@ -77,11 +77,9 @@ export class CompileContract extends Command {
             build.stderr.on("data", () => spinner.ora.clear());
             build.stderr.pipe(process.stdout);
           }
-          build.on("error", (error) => {
-            reject(error);
-          });
-          build.on("exit", () => {
-            resolve();
+          build.on("exit", (code) => {
+            if (code === 0) resolve();
+            else reject();
           });
         });
       },


### PR DESCRIPTION
`swanky contract compile` command should fail and exit process if contracts compilation fails.