### PR TITLE
contract explain command

### DIFF
--- a/packages/cli/src/commands/contract/explain.ts
+++ b/packages/cli/src/commands/contract/explain.ts
@@ -2,11 +2,7 @@ import { BaseCommand } from "../../lib/baseCommand";
 import * as fs from "fs-extra";
 import path = require("node:path");
 import { readdirSync } from "node:fs";
-import {
-  ensureSwankyProject,
-  getSwankyConfig,
-  printContractInfo,
-} from "@astar-network/swanky-core";
+import { printContractInfo } from "@astar-network/swanky-core";
 
 export class ExplainContract extends BaseCommand<typeof ExplainContract> {
   static description = "Explain contract messages based on thier metadata";
@@ -22,11 +18,7 @@ export class ExplainContract extends BaseCommand<typeof ExplainContract> {
   async run(): Promise<void> {
     const { args } = await this.parse(ExplainContract);
 
-    await ensureSwankyProject();
-
-    const config = await getSwankyConfig();
-
-    const contractInfo = config.contracts[args.contractName];
+    const contractInfo = this.swankyConfig.contracts[args.contractName];
     if (!contractInfo) {
       this.error(`Cannot find a contract named ${args.contractName} in swanky.config.json`);
     }

--- a/packages/cli/src/commands/contract/explain.ts
+++ b/packages/cli/src/commands/contract/explain.ts
@@ -1,4 +1,4 @@
-import { Command } from "@oclif/core";
+import { BaseCommand } from "../../lib/baseCommand";
 import * as fs from "fs-extra";
 import path = require("node:path");
 import { readdirSync } from "node:fs";
@@ -8,7 +8,7 @@ import {
   printContractInfo,
 } from "@astar-network/swanky-core";
 
-export class ExplainContract extends Command {
+export class ExplainContract extends BaseCommand<typeof ExplainContract> {
   static description = "Explain contract messages based on thier metadata";
 
   static args = [

--- a/packages/cli/src/commands/contract/explain.ts
+++ b/packages/cli/src/commands/contract/explain.ts
@@ -1,0 +1,53 @@
+import { Command } from "@oclif/core";
+import * as fs from "fs-extra";
+import path = require("node:path");
+import { readdirSync } from "node:fs";
+import {
+  ensureSwankyProject,
+  getSwankyConfig,
+  printContractInfo,
+} from "@astar-network/swanky-core";
+
+export class ExplainContract extends Command {
+  static description = "Explain contract messages based on thier metadata";
+
+  static args = [
+    {
+      name: "contractName",
+      required: true,
+      description: "Name of the contract",
+    },
+  ];
+
+  async run(): Promise<void> {
+    const { args } = await this.parse(ExplainContract);
+
+    await ensureSwankyProject();
+
+    const config = await getSwankyConfig();
+
+    const contractInfo = config.contracts[args.contractName];
+    if (!contractInfo) {
+      this.error(`Cannot find a contract named ${args.contractName} in swanky.config.json`);
+    }
+
+    const contractList = readdirSync(path.resolve("contracts"));
+
+    const contractPath = path.resolve("contracts", args.contractName);
+    if (!contractList.includes(args.contractName)) {
+      this.error(`Path to contract ${args.contractName} does not exist: ${contractPath}`);
+    }
+
+    if (!contractInfo.build) {
+      this.error(`No build data for contract "${args.contractName}"`);
+    }
+    
+    const metadataPath = path.resolve(contractInfo.build?.artifactsPath, `${args.contractName}.json`);
+    if (!fs.existsSync(metadataPath)) {
+        this.error(`Metadata json file for ${args.contractName} contract not found`);
+    }
+
+    printContractInfo(metadataPath)
+  }
+}
+

--- a/packages/core/src/lib/command-utils.ts
+++ b/packages/core/src/lib/command-utils.ts
@@ -6,6 +6,7 @@ import path = require("node:path");
 import { DEFAULT_NETWORK_URL, ARTIFACTS_PATH, TYPED_CONTRACT_PATH } from "./consts.js";
 import { BuildData, ContractData, SwankyConfig } from "../types";
 import { generateTypes } from "./tasks.js";
+import { Abi } from "@polkadot/api-contract";
 
 export async function commandStdoutOrNull(command: string): Promise<string | null> {
   try {
@@ -167,4 +168,47 @@ export async function moveArtifacts(
   }
 
   return buildData;
+}
+
+export async function printContractInfo(metadataPath: string) {
+  const abi = new Abi((await fs.readJson(metadataPath)));
+
+  // TODO: Use templating, colorize.
+
+  console.log(`
+    😎 ${abi.info.contract.name} Contract 😎
+
+    Hash: ${abi.info.source.hash}
+    Language: ${abi.info.source.language}
+    Compiler: ${abi.info.source.compiler}
+  `)
+
+  console.log(`    === Constructors ===\n`)
+  for (const constructor of abi.constructors) {
+    console.log(`    * ${constructor.method}:
+        Args: ${constructor.args.length > 0 ? constructor.args.map((arg) => {
+          return `\n        - ${arg.name} (${arg.type.displayName})`
+        }) : "None"}
+        Description: ${constructor.docs.map((line) => {
+          if (line != "") {
+            return `\n         ` + line
+          }
+        })}
+    `)
+  }
+
+  console.log(`    === Messages ===\n`)
+  for (const message of abi.messages) {
+    console.log(`    * ${message.method}:
+        Payable: ${message.isPayable}
+        Args: ${message.args.length > 0 ? message.args.map((arg) => {
+          return `\n        - ${arg.name} (${arg.type.displayName})`
+        }) : "None"}
+        Description: ${message.docs.map((line) => {
+          if (line != "") {
+            return `\n         ` + line
+          }
+        })}
+    `)
+  }
 }


### PR DESCRIPTION
Simple implementation of contract explain command using `console.log`s.
Better using templating and colonization for more visibility.

<img width="1512" alt="Screen Shot 2023-02-10 at 16 35 47" src="https://user-images.githubusercontent.com/28953860/218030686-09ad4a0a-6ba2-4bc1-8b0d-afae5e4164ee.png">