### PR TITLE
Fix typegen command, move typedContract

### DIFF
--- a/packages/cli/src/commands/contract/typegen.ts
+++ b/packages/cli/src/commands/contract/typegen.ts
@@ -72,7 +72,7 @@ export class CompileContract extends Command {
 
       await generateTypes(ARTIFACTS_PATH, TYPED_CONTRACT_PATH);
       
-      await fs.copy(TYPED_CONTRACT_PATH, destinationPath);
+      await fs.move(TYPED_CONTRACT_PATH, destinationPath);
 
       // Need to cleanup files inside artifacts folder, because typechain-polkadot generate types for all files under input folder.
       // Residues affects the result of next contract's type generation.


### PR DESCRIPTION
current typegen command leave typedContracts at `TYPED_CONTRACT_PATH`, this should be moved to under test test folder.