### PR TITLE
Fix contract metadata json name

### DIFF
--- a/packages/core/src/lib/command-utils.ts
+++ b/packages/core/src/lib/command-utils.ts
@@ -88,7 +88,7 @@ export async function generateTypesFor(
         path.resolve(ARTIFACTS_PATH, `${contractName}.contract`),
       ),
       fs.copyFile(
-        path.resolve(contractPath, "target", "ink", "metadata.json"),
+        path.resolve(contractPath, "target", "ink", `${contractName}.json`),
         path.resolve(ARTIFACTS_PATH, `${contractName}.json`),
       )
     ])


### PR DESCRIPTION
When executing `swanky contract compile` command in cargo-contract 2.0.0 and ink4.0 environment, it gets error below because of exported file name changed `metadata.json` to `${contractName}.json`, so that it should be fixed.

```shell
✖ Error Generating contract ts types
```