### PR TITLE
Suppress error when yarn is not installed

### DIFF
--- a/packages/core/src/lib/tasks.ts
+++ b/packages/core/src/lib/tasks.ts
@@ -130,6 +130,8 @@ export async function installDeps(projectPath: string) {
   try {
     await execa.command("yarn --version");
     installCommand = "yarn install";
+  } catch (_error) {
+    console.log("\n\t >>Yarn not detected, using NPM");
   } finally {
     await execa.command(installCommand, { cwd: projectPath });
   }


### PR DESCRIPTION
There's a try/finally block that switches between yarn and npm package managers, but when yarn is not installed, the `yarn --version` command shows an error even though it correctly proceeds to install with npm.

This PR adds a catch block to suppress that error and print out info about using npm instead.

closes #57 