### PR TITLE
Uplift to ink v4

### DIFF
--- a/packages/core/src/lib/command-utils.ts
+++ b/packages/core/src/lib/command-utils.ts
@@ -88,7 +88,7 @@ export async function generateTypesFor(
         path.resolve(ARTIFACTS_PATH, `${contractName}.contract`),
       ),
       fs.copyFile(
-        path.resolve(contractPath, "target", "ink", "metadata.json"),
+        path.resolve(contractPath, "target", "ink", `${contractName}.json`),
         path.resolve(ARTIFACTS_PATH, `${contractName}.json`),
       )
     ])

--- a/packages/core/src/lib/nodeInfo.ts
+++ b/packages/core/src/lib/nodeInfo.ts
@@ -1,13 +1,13 @@
 export type nodeInfo = typeof swankyNode;
 
 export const swankyNode = {
-  version: "1.0.0",
-  polkadotPalletVersions: "polkadot-v0.9.33",
+  version: "1.1.0",
+  polkadotPalletVersions: "polkadot-v0.9.37",
   supportedInk: "v4.0.0",
   downloadUrl: {
     darwin:
-      "https://github.com/AstarNetwork/swanky-node/releases/download/v1.0.0/swanky-node-v1.0.0-macOS-x86_64.tar.gz",
+      "https://github.com/AstarNetwork/swanky-node/releases/download/v1.1.0/swanky-node-v1.1.0-macOS-x86_64.tar.gz",
     linux:
-      "https://github.com/AstarNetwork/swanky-node/releases/download/v1.0.0/swanky-node-v1.0.0-ubuntu-x86_64.tar.gz",
+      "https://github.com/AstarNetwork/swanky-node/releases/download/v1.1.0/swanky-node-v1.1.0-ubuntu-x86_64.tar.gz",
   },
 };

--- a/packages/templates/src/templates/contracts/ink/blank/contract/Cargo.toml.hbs
+++ b/packages/templates/src/templates/contracts/ink/blank/contract/Cargo.toml.hbs
@@ -5,16 +5,10 @@ authors = ["{{author_name}}"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "3.4.0", default-features = false }
-ink_metadata = { version = "3.4.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.4.0", default-features = false }
-ink_storage = { version = "3.4.0", default-features = false }
-ink_lang = { version = "3.4.0", default-features = false }
-ink_prelude = { version = "3.4.0", default-features = false }
-ink_engine = { version = "3.4.0", default-features = false, optional = true }
+ink = { version = "4.0.0", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "{{contract_name_snake}}"
@@ -27,11 +21,8 @@ crate-type = [
 [features]
 default = ["std"]
 std = [
-    "ink_metadata/std",
-    "ink_env/std",
-    "ink_storage/std",
-    "ink_primitives/std",
+    "ink/std",
     "scale/std",
-    "scale-info/std",
+    "scale-info/std"
 ]
 ink-as-dependency = []

--- a/packages/templates/src/templates/contracts/ink/blank/contract/src/lib.rs.hbs
+++ b/packages/templates/src/templates/contracts/ink/blank/contract/src/lib.rs.hbs
@@ -1,6 +1,4 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use ink_lang as ink;
-
 #[ink::contract]
 mod {{contract_name_snake}} {}

--- a/packages/templates/src/templates/contracts/ink/flipper/contract/Cargo.toml.hbs
+++ b/packages/templates/src/templates/contracts/ink/flipper/contract/Cargo.toml.hbs
@@ -5,32 +5,23 @@ authors = ["{{author_name}}"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "3.4.0", default-features = false }
-ink_metadata = { version = "3.4.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.4.0", default-features = false }
-ink_storage = { version = "3.4.0", default-features = false }
-ink_lang = { version = "3.4.0", default-features = false }
-ink_prelude = { version = "3.4.0", default-features = false }
-ink_engine = { version = "3.4.0", default-features = false, optional = true }
+ink = { version = "4.0.0", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "{{contract_name_snake}}"
 path = "src/lib.rs"
 crate-type = [
-	# Used for normal contract Wasm blobs.
-	"cdylib",
+    # Used for normal contract Wasm blobs.
+    "cdylib",
 ]
 
 [features]
 default = ["std"]
 std = [
-    "ink_metadata/std",
-    "ink_env/std",
-    "ink_storage/std",
-    "ink_primitives/std",
+    "ink/std",
     "scale/std",
     "scale-info/std",
 ]

--- a/packages/templates/src/templates/contracts/ink/flipper/contract/src/lib.rs.hbs
+++ b/packages/templates/src/templates/contracts/ink/flipper/contract/src/lib.rs.hbs
@@ -1,7 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use ink_lang as ink;
-
 #[ink::contract]
 mod {{contract_name_snake}} {
 
@@ -55,9 +53,6 @@ mod {{contract_name_snake}} {
     mod tests {
         /// Imports all the definitions from the outer scope so we can use them here.
         use super::*;
-
-        /// Imports `ink_lang` so we can use `#[ink::test]`.
-        use ink_lang as ink;
 
         /// We test if the default constructor does its job.
         #[ink::test]

--- a/packages/templates/src/templates/contracts/ink/psp22/contract/Cargo.toml.hbs
+++ b/packages/templates/src/templates/contracts/ink/psp22/contract/Cargo.toml.hbs
@@ -5,19 +5,13 @@ authors = ["{{author_name}}"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "3.4.0", default-features = false }
-ink_metadata = { version = "3.4.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.4.0", default-features = false }
-ink_storage = { version = "3.4.0", default-features = false }
-ink_lang = { version = "3.4.0", default-features = false }
-ink_prelude = { version = "3.4.0", default-features = false }
-ink_engine = { version = "3.4.0", default-features = false, optional = true }
+ink = { version = "4.0.0", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 
 # These dependencies
-openbrush = { tag = "v2.3.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["psp22"] }
+openbrush = { git = "https://github.com/727-Ventures/openbrush-contracts", version = "3.0.0", default-features = false, features = ["psp22"] }
 
 [lib]
 name = "{{contract_name_snake}}"
@@ -30,14 +24,8 @@ crate-type = [
 [features]
 default = ["std"]
 std = [
-    "ink_primitives/std",
-    "ink_metadata",
-    "ink_metadata/std",
-    "ink_env/std",
-    "ink_storage/std",
-    "ink_lang/std",
+    "ink/std",
     "scale/std",
-    "scale-info",
     "scale-info/std",
 
     # These dependencies

--- a/packages/templates/src/templates/contracts/ink/psp22/contract/src/lib.rs.hbs
+++ b/packages/templates/src/templates/contracts/ink/psp22/contract/src/lib.rs.hbs
@@ -3,8 +3,7 @@
 
 #[openbrush::contract]
 pub mod {{contract_name_snake}} {
-    use ink_storage::traits::SpreadAllocate;
-    use ink_lang::codegen::{Env, EmitEvent};
+    use ink::codegen::{Env, EmitEvent};
     use openbrush::{
         contracts::psp22::*,
         traits::{
@@ -32,12 +31,19 @@ pub mod {{contract_name_snake}} {
     }
 
     #[ink(storage)]
-    #[derive(Default, SpreadAllocate, Storage)]
+    #[derive(Storage)]
     pub struct {{contract_name_pascal}} {
         #[storage_field]
         psp22: psp22::Data,
         // fields for hater logic
         hated_account: AccountId,
+    }
+
+    impl Default for {{contract_name_pascal}} {
+        fn default() -> Self {
+            psp22: Default::default(),
+            hated_account: [0u8; 32].into(),
+        }
     }
 
     impl Transfer for {{contract_name_pascal}} {
@@ -83,11 +89,11 @@ pub mod {{contract_name_snake}} {
     impl {{contract_name_pascal}} {
         #[ink(constructor)]
         pub fn new(total_supply: Balance) -> Self {
-            ink_lang::codegen::initialize_contract(|instance: &mut {{contract_name_pascal}}| {
-                instance
-                    ._mint_to(instance.env().caller(), total_supply)
-                    .expect("Should mint");
-            })
+            let mut instance = Self::default();
+            instance
+                ._mint_to(instance.env().caller(), total_supply)
+                .expect("Should mint");
+            instance
         }
 
         #[ink(message)]

--- a/packages/templates/src/templates/contracts/ink/psp22/test/psp22.test.ts.hbs
+++ b/packages/templates/src/templates/contracts/ink/psp22/test/psp22.test.ts.hbs
@@ -13,7 +13,6 @@ const wsProvider = new WsProvider("ws://127.0.0.1:9944");
 const keyring = new Keyring({ type: "sr25519" });
 
 const EMPTY_ADDRESS = "5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM";
-const GAS_REQUIRED = 500000;
 describe("{{contract_name}} test", () => {
   let {{contract_name}}Factory: {{contract_name_pascal}}Factory;
   let api: ApiPromise;
@@ -43,9 +42,8 @@ describe("{{contract_name}} test", () => {
   });
 
   it("Assigns initial balance", async () => {
-    const queryList = await contract.query;
     expect(
-      (await contract.query.totalSupply()).value.rawNumber.toNumber()
+      (await contract.query.totalSupply()).value.ok.rawNumber.toNumber()
     ).to.equal(maxSupply);
   });
 
@@ -61,10 +59,10 @@ describe("{{contract_name}} test", () => {
     });
 
     await expect(
-      (await contract.query.balanceOf(wallet1.address)).value.toNumber()
+      (await contract.query.balanceOf(wallet1.address)).value.ok.toNumber()
     ).to.be.equal(transferredAmount);
     await expect(
-      (await contract.query.balanceOf(contract.signer.address)).value.toNumber()
+      (await contract.query.balanceOf(contract.signer.address)).value.ok.toNumber()
     ).to.be.equal(maxSupply - transferredAmount);
   });
 
@@ -96,7 +94,7 @@ describe("{{contract_name}} test", () => {
     ).to.eventually.be.fulfilled;
 
     let result = await contract.query.balanceOf(hated_account.address);
-    expect(result.value.toNumber()).to.equal(transferredAmount);
+    expect(result.value.ok.toNumber()).to.equal(transferredAmount);
 
     expect((await contract.query.getHatedAccount()).value).to.equal(
       EMPTY_ADDRESS
@@ -121,7 +119,7 @@ describe("{{contract_name}} test", () => {
 
     // Amount of tokens must be the same
     expect(
-      (await contract.query.balanceOf(hated_account.address)).value.toNumber()
+      (await contract.query.balanceOf(hated_account.address)).value.ok.toNumber()
     ).to.equal(10);
   });
 });


### PR DESCRIPTION
Now [cargo contract](https://github.com/paritytech/cargo-contract) released the stable version of v2.0.1, and it only supports from ink v4. Closes #105. Also partly handles #109 (the ink version part).