### PR TITLE
Fix change moving artifact file to fileCopy

### DIFF
--- a/packages/core/src/lib/command-utils.ts
+++ b/packages/core/src/lib/command-utils.ts
@@ -151,15 +151,14 @@ export async function moveArtifacts(
     await fs.ensureDir(testArtifacts);
     await fs.ensureDir(testTypedContracts)
     await Promise.all([
-      fs.move(
+      fs.copyFile(
         path.resolve(ARTIFACTS_PATH, `${contractName}.contract`),
-        `${testArtifacts}/${contractName}.contract`,
-        { overwrite: true }
+        `${testArtifacts}/${contractName}.contract`        
       ),
       fs.move(
         path.resolve(ARTIFACTS_PATH, `${contractName}.json`),
         `${testArtifacts}/${contractName}.json`,
-        { overwrite: true }
+        { overwrite: true }     
       ),
       fs.move(TYPED_CONTRACT_PATH, testTypedContracts, {
         overwrite: true,

--- a/packages/core/src/lib/command-utils.ts
+++ b/packages/core/src/lib/command-utils.ts
@@ -158,7 +158,7 @@ export async function moveArtifacts(
       fs.move(
         path.resolve(ARTIFACTS_PATH, `${contractName}.json`),
         `${testArtifacts}/${contractName}.json`,
-        { overwrite: true }     
+        { overwrite: true }
       ),
       fs.move(TYPED_CONTRACT_PATH, testTypedContracts, {
         overwrite: true,


### PR DESCRIPTION
when executed command below in swanky project folder inited with flipper contract.

```shell
cd flipper
swanky contract compile flipper -v
yarn test
```

It gets this error.

```shell
Error: ENOENT: no such file or directory, open './artifacts/flipper.contract'
```

It is because `./test/flipper/typedContract/constructors/flipper.ts` has code below and it indicated `./artifacts/flipper.contract` but  the file was moved to test folder.

```ts
const __contract = JSON.parse(Files.readFileSync("./artifacts/flipper.contract").toString());
```
Therefore I suggest  to use  fileCopy instead of move.