### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # How to use
-swanky-cli installation and how-to-use guides are available in the official swanky suite [doc](https://docs.astar.network/docs/build/wasm/swanky/).
+swanky-cli installation and how-to-use guides are available in the official swanky suite [docs](https://docs.astar.network/docs/build/wasm/swanky-suite/).
 
 # Repository Structure
 
-Repo is split into separate packages, and uses [Lerna](https://github.com/lerna/lerna) to handle builds/versioning.
+The repo is split into separate packages, and uses [Lerna](https://github.com/lerna/lerna) to handle builds/versioning.
 
 ## `cli`
 


### PR DESCRIPTION
Fixes a broken link on the README page.

Old link: https://docs.astar.network/docs/build/wasm/swanky/

Correct link AFAIK: https://docs.astar.network/docs/build/wasm/swanky-suite/