### PR TITLE
Check platform and arch

### DIFF
--- a/packages/cli/src/commands/check/index.ts
+++ b/packages/cli/src/commands/check/index.ts
@@ -1,4 +1,4 @@
-import { Command } from "@oclif/core";
+import { BaseCommand } from "../../lib/baseCommand";
 import { Listr } from "listr2";
 import { commandStdoutOrNull, ensureSwankyProject, SwankyConfig } from "@astar-network/swanky-core";
 import fs = require("fs-extra");
@@ -7,12 +7,12 @@ import toml = require("toml");
 import semver = require("semver");
 
 interface Ctx {
+  platform: string;
+  architecture: string;
   versions: {
     tools: {
       rust?: string | null;
       cargo?: string | null;
-      cargoNightly?: string | null;
-      cargoDylint?: string | null;
       cargoContract?: string | null;
     };
     contracts: { [key: string]: { [key: string]: string } };
@@ -24,12 +24,19 @@ interface Ctx {
   looseDefinitionDetected: boolean;
 }
 
-export default class Check extends Command {
+export default class Check extends BaseCommand<typeof Check>  {
   static description = "Check installed package versions and compatibility";
 
   public async run(): Promise<void> {
     await ensureSwankyProject();
     const tasks = new Listr<Ctx>([
+      {
+        title: "Check platform and architecture",
+        task: async (ctx) => {
+          ctx.platform = process.platform;
+          ctx.architecture = process.arch;
+        },
+      },
       {
         title: "Check Rust",
         task: async (ctx) => {
@@ -43,18 +50,6 @@ export default class Check extends Command {
         },
       },
       {
-        title: "Check cargo nightly",
-        task: async (ctx) => {
-          ctx.versions.tools.cargoNightly = await commandStdoutOrNull("cargo +nightly -V");
-        },
-      },
-      {
-        title: "Check cargo dylint",
-        task: async (ctx) => {
-          ctx.versions.tools.cargoDylint = await commandStdoutOrNull("cargo dylint -V");
-        },
-      },
-      {
         title: "Check cargo-contract",
         task: async (ctx) => {
           ctx.versions.tools.cargoContract = await commandStdoutOrNull("cargo contract -V");
@@ -63,10 +58,9 @@ export default class Check extends Command {
       {
         title: "Read ink dependencies",
         task: async (ctx) => {
-          const swankyConfig = await fs.readJSON("swanky.config.json");
-          ctx.swankyConfig = swankyConfig;
+          ctx.swankyConfig = this.swankyConfig;
           const contractInkVersions = {};
-          for (const contract in swankyConfig.contracts) {
+          for (const contract in this.swankyConfig.contracts) {
             const tomlPath = path.resolve(`contracts/${contract}/Cargo.toml`);
             const doesCargoTomlExist = fs.pathExistsSync(tomlPath);
             if (!doesCargoTomlExist) {
@@ -81,7 +75,7 @@ export default class Check extends Command {
             const cargoToml = toml.parse(cargoTomlString);
 
             const inkDependencies = Object.entries(cargoToml.dependencies)
-              .filter((dependency) => dependency[0].includes("ink_"))
+              .filter((dependency) => dependency[0].includes("ink"))
               .map(([depName, depInfo]) => {
                 const dependency = <Dependency>depInfo;
                 return [depName, dependency.version || dependency.tag];
@@ -114,16 +108,32 @@ export default class Check extends Command {
         },
       },
     ]);
+
     const context = await tasks.run({
+      platform: "",
+      architecture: "",
       versions: { tools: {}, contracts: {} },
       looseDefinitionDetected: false,
     });
+
+    console.log("Platform: " + context.platform);
+    console.log("Architecture: " + context.architecture);
     console.log(context.versions);
+
+    const supportedPlatform = ["darwin", "linux"];
+    const supportedOS = ["arm64", "x64"];
+    if (!supportedPlatform.includes(context.platform)) {
+      console.error("[ERROR] Unsupported platform: " + context.platform);
+    }
+    if (!supportedOS.includes(context.architecture)) {
+      console.error("[ERROR] Unsupported architecture: " + context.architecture);
+    }
+
     Object.values(context.mismatchedVersions as any).forEach((mismatch) =>
       console.error(`[ERROR] ${mismatch}`)
     );
     if (context.looseDefinitionDetected) {
-      console.log(`\n[WARNING]Some of the ink dependencies do not have a fixed version.
+      console.log(`\n[WARNING] Some of the ink dependencies do not have a fixed version.
       This can lead to accidentally installing version higher than supported by the node.
       Please use "=" to install a fixed version (Example: "=3.0.1")
       `);

--- a/packages/core/src/lib/nodeInfo.ts
+++ b/packages/core/src/lib/nodeInfo.ts
@@ -1,13 +1,17 @@
 export type nodeInfo = typeof swankyNode;
 
 export const swankyNode = {
-  version: "1.1.0",
-  polkadotPalletVersions: "polkadot-v0.9.37",
+  version: "1.5.0",
+  polkadotPalletVersions: "polkadot-v0.9.39",
   supportedInk: "v4.0.0",
   downloadUrl: {
-    darwin:
-      "https://github.com/AstarNetwork/swanky-node/releases/download/v1.1.0/swanky-node-v1.1.0-macOS-x86_64.tar.gz",
-    linux:
-      "https://github.com/AstarNetwork/swanky-node/releases/download/v1.1.0/swanky-node-v1.1.0-ubuntu-x86_64.tar.gz",
+    darwin: {
+      "arm64": "https://github.com/AstarNetwork/swanky-node/releases/download/v1.5.0/swanky-node-v1.5.0-macOS-universal.tar.gz",
+      "x64": "https://github.com/AstarNetwork/swanky-node/releases/download/v1.5.0/swanky-node-v1.5.0-macOS-universal.tar.gz"
+    },
+    linux: {
+      "arm64": "https://github.com/AstarNetwork/swanky-node/releases/download/v1.5.0/swanky-node-v1.5.0-ubuntu-aarch64.tar.gz",
+      "x64": "https://github.com/AstarNetwork/swanky-node/releases/download/v1.5.0/swanky-node-v1.5.0-ubuntu-x86_64.tar.gz",
+    }
   },
 };

--- a/packages/core/src/lib/tasks.ts
+++ b/packages/core/src/lib/tasks.ts
@@ -1,5 +1,5 @@
 import execa from "execa";
-import { ensureDir, rename, copy, readFile, rm, writeFile, remove, pathExists } from "fs-extra";
+import { ensureDir, rename, copy, readFile, rm, writeFile, remove } from "fs-extra";
 import path from "node:path";
 import globby from "globby";
 import handlebars from "handlebars";
@@ -91,7 +91,7 @@ export async function processTemplates(projectPath: string, templateData: Record
 export async function downloadNode(projectPath: string, nodeInfo: nodeInfo, spinner: Spinner) {
   const binPath = path.resolve(projectPath, "bin");
   await ensureDir(binPath);
-  const dlUrl = nodeInfo.downloadUrl[process.platform];
+  const dlUrl = nodeInfo.downloadUrl[process.platform][process.arch];
 
   if (!dlUrl)
     throw new Error(`Could not download swanky-node. Platform ${process.platform} not supported!`);


### PR DESCRIPTION
Check platform and arch.
Resolve https://github.com/AstarNetwork/swanky-cli/issues/114

Also,
cargo contract doesn't require dylint as prerequisites, and stable rust toolchain is recommended to use after cargo contract v2.0.0.