### PR TITLE
fix Cargo workspace config

### DIFF
--- a/packages/templates/src/templates/Cargo.toml
+++ b/packages/templates/src/templates/Cargo.toml
@@ -1,5 +1,4 @@
 [workspace]
 members = [
     "contracts/*",
-    "crates/*",
 ]


### PR DESCRIPTION

<img width="1166" alt="Screen Shot 2023-04-25 at 19 36 22" src="https://user-images.githubusercontent.com/28953860/234251911-b2c4845a-be82-4960-8e08-bec415e4f794.png">


Having issue if users don't have Cargo.toml under crates folder which is planned to be created by convert command.