### PR TITLE
fix typechain typedContract bug

### DIFF
--- a/packages/templates/src/templates/package.json.hbs
+++ b/packages/templates/src/templates/package.json.hbs
@@ -18,8 +18,8 @@
     {{#if_eq contract_language "ask"}}
     "ask-lang": "^0.4.0-rc3",
     {{/if_eq}}
-    "@727-ventures/typechain-types": "0.0.22",
-    "@727-ventures/typechain-polkadot": "0.6.10",
+    "@727-ventures/typechain-types": "1.0.0-beta.1",
+    "@727-ventures/typechain-polkadot": "1.0.0-beta.2",
     "typescript": "^4.9.3"
 },
   "devDependencies": {


### PR DESCRIPTION
typechain polkadot start to get JSON parse error for some reason.
Updating dependency to bugfix version can resolve JSON parse error in `swanky contract test`.
https://github.com/Brushfam/typechain-polkadot/issues/53

<img width="1476" alt="Screen Shot 2023-04-24 at 16 48 55" src="https://user-images.githubusercontent.com/28953860/234815516-d7614eba-e49a-4d2f-a3db-0261ecd50804.png">
