### PR TITLE
Fix typedContract folder move failure

### DIFF
--- a/packages/core/src/lib/command-utils.ts
+++ b/packages/core/src/lib/command-utils.ts
@@ -134,7 +134,7 @@ export async function printContractInfo(metadataPath: string) {
   }
 }
 
-export async function generateTypes(inputAbsPath: string, contractName: string, outputAbsPath: string) {
+export async function generateTypes(inputPath: string, contractName: string, outputPath: string) {
   await fs.ensureDir(TEMP_ARTIFACTS_PATH);
 
   // Getting error if typechain-polkadot takes folder with unnecessary files/folders as inputs.
@@ -150,15 +150,15 @@ export async function generateTypes(inputAbsPath: string, contractName: string, 
   // Cannot generate typedContract directly to `outputAbsPath`
   // because relative path of typechain-polkadot input and output folder does matter for later use.
   await fs.copyFile(
-    path.resolve(inputAbsPath, `${contractName}.contract`),
+    path.resolve(inputPath, `${contractName}.contract`),
     path.resolve(TEMP_ARTIFACTS_PATH, `${contractName}.contract`),
   ),
   await fs.copyFile(
-    path.resolve(inputAbsPath, `${contractName}.json`),
+    path.resolve(inputPath, `${contractName}.json`),
     path.resolve(TEMP_ARTIFACTS_PATH, `${contractName}.json`),
   )
 
   await execa.command(`npx typechain-polkadot --in ${TEMP_ARTIFACTS_PATH} --out ${TEMP_TYPED_CONTRACT_PATH}`);
 
-  await fs.move(path.resolve(TEMP_TYPED_CONTRACT_PATH), outputAbsPath, { overwrite: true })
+  await fs.move(path.resolve(TEMP_TYPED_CONTRACT_PATH), outputPath, { overwrite: true })
 }

--- a/packages/core/src/lib/command-utils.ts
+++ b/packages/core/src/lib/command-utils.ts
@@ -160,5 +160,5 @@ export async function generateTypes(inputAbsPath: string, contractName: string, 
 
   await execa.command(`npx typechain-polkadot --in ${TEMP_ARTIFACTS_PATH} --out ${TEMP_TYPED_CONTRACT_PATH}`);
 
-  await fs.move(path.resolve(TEMP_TYPED_CONTRACT_PATH), outputAbsPath)
+  await fs.move(path.resolve(TEMP_TYPED_CONTRACT_PATH), outputAbsPath, { overwrite: true })
 }


### PR DESCRIPTION
Compile command will fail at the Generating TS types phase after the second time, because fs.move fail if the same name folder exist in the destination path.
Added `overwrite` option so that `typedContract` moved to the correct path as expected.