### PR TITLE
removed typechain compiler config

### DIFF
--- a/packages/templates/src/templates/config.json.hbs
+++ b/packages/templates/src/templates/config.json.hbs
@@ -1,5 +1,0 @@
-{
-  "projectFiles": ["contracts/**/*"],
-  "artifactsPath": "artifacts",
-  "typechainGeneratedPath": "typedContract"
-}


### PR DESCRIPTION
Not using typechain-compiler, we should remove it from templates.