### PR TITLE
fix: remove double template processing

### DIFF
--- a/src/commands/init/index.ts
+++ b/src/commands/init/index.ts
@@ -136,19 +136,8 @@ export class Init extends BaseCommand {
       runningMessage: "Copying common template files",
     });
 
-    this.taskQueue.push({
-      task: processTemplates,
-      args: [
-        this.projectPath,
-        {
-          project_name: paramCase(args.projectName),
-        },
-      ],
-      runningMessage: "Processing common templates",
-    });
-
     if (flags.convert) {
-      await this.convert(flags.convert);
+      await this.convert(flags.convert, args.projectName);
     } else {
       await this.generate(args.projectName);
     }
@@ -295,7 +284,7 @@ export class Init extends BaseCommand {
           contract_name_pascal: pascalCase(contractName),
         },
       ],
-      runningMessage: "Processing contract template",
+      runningMessage: "Processing templates",
     });
 
     this.configBuilder.contracts = {
@@ -307,7 +296,7 @@ export class Init extends BaseCommand {
     };
   }
 
-  async convert(pathToExistingProject: string) {
+  async convert(pathToExistingProject: string, projectName: string) {
     try {
       const pathStat = await stat(pathToExistingProject);
       if (pathStat.isDirectory()) {
@@ -348,6 +337,18 @@ export class Init extends BaseCommand {
         : [];
 
     const confirmedCopyList = await detectModuleNames(await confirmCopyList(candidatesList));
+
+    this.taskQueue.push({
+      task: processTemplates,
+      args: [
+        this.projectPath,
+        {
+          project_name: paramCase(projectName),
+          swanky_version: this.config.pjson.version,
+        },
+      ],
+      runningMessage: "Processing templates",
+    });
 
     this.taskQueue.push({
       task: copyWorkspaceContracts,

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -63,25 +63,13 @@ export async function processTemplates(projectPath: string, templateData: Record
     expandDirectories: { extensions: ["hbs"] },
   });
 
-  handlebars.registerHelper("if_eq", function (a, b, options): boolean {
-    if (a === b) {
-      // @ts-ignore
-      return options.fn(this);
-    } else {
-      // @ts-ignore
-      return options.inverse(this);
-    }
-  });
-
-  await Promise.all(
-    templateFiles.map(async (tplFilePath) => {
-      const rawTemplate = await readFile(tplFilePath, "utf8");
-      const template = handlebars.compile(rawTemplate);
-      const compiledFile = template(templateData);
-      await rm(tplFilePath);
-      await writeFile(tplFilePath.split(".hbs")[0], compiledFile);
-    })
-  );
+  for (const tplFilePath of templateFiles) {
+    const rawTemplate = await readFile(tplFilePath, "utf8");
+    const template = handlebars.compile(rawTemplate);
+    const compiledFile = template(templateData);
+    await rm(tplFilePath);
+    await writeFile(tplFilePath.split(".hbs")[0], compiledFile);
+  }
 }
 
 export async function downloadNode(projectPath: string, nodeInfo: nodeInfo, spinner: Spinner) {


### PR DESCRIPTION
Templates were being processed twice, making the second run irrelevant.

This moves the processing to after all the needed data has been collected.

Also removes the custom `if_eq` helper that's not needed anymore since there's no language choices.


Will be promoted from draft after #166 is merged and this rebased to master.